### PR TITLE
Remove reading analogue pins 4 and 5 from the analogue-read command

### DIFF
--- a/src/firmware.cpp
+++ b/src/firmware.cpp
@@ -148,8 +148,6 @@ static CommandError analogue_read(String argument) {
   read_analogue_pin_to_serial("a1", A1);
   read_analogue_pin_to_serial("a2", A2);
   read_analogue_pin_to_serial("a3", A3);
-  read_analogue_pin_to_serial("a4", A4);
-  read_analogue_pin_to_serial("a5", A5);
   return OK;
 }
 


### PR DESCRIPTION
These pins are used by the I²C connection to the servo shield, and therefore shouldn't be used as actual analogue inputs.