### PR TITLE
Clone submodules using git protocol instead of https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libraries/Adafruit-PWM-Servo-Driver-Library"]
 	path = libraries/Adafruit-PWM-Servo-Driver-Library
-	url = https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library/
+	url = git://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ general:
 
 dependencies:
     pre:
+        - sudo apt-get update -y
         - sudo apt-get install arduino arduino-core arduino-mk
         # This library wont build under circle, and seems to be absent locally The dependency is provided by another library, so we can delete it!
         - sudo rm -rf /usr/share/arduino/libraries/Robot_Control


### PR DESCRIPTION
This fixes circleci not being able to clone submodules, without
requiring a github user key.

Annoyingly CI is now failing in apt-get (hopefully this is transient behaviour).