### PR TITLE
Fix CI in rewrite branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,11 @@ jobs:
   build:
     docker:
       - image: slocomptech/docker-arduino
-    working_directory: ~/project/src/src
     steps:
       - checkout
       - run:
-          name: Install Servo Library
-          command: arduino_install_lib https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library.git
+          name: Checkout submodules
+          command: git submodule sync && git submodule update --init
       - run:
           name: Build Sketch
-          command: arduino_build_sketch src.ino arduino:avr:uno
+          command: arduino-builder -hardware ${ARDUINO_HARDWARE} -tools ${ARDUINO_TOOLS}/avr -tools ${ARDUINO_TOOLS_BUILDER} -libraries ${ARDUINO_LIBS} -libraries libraries/ -fqbn arduino:avr:uno src/firmware.cpp


### PR DESCRIPTION
Fix CI build in #16. 

The issue was caused by an incorrect path. The script was also building the wrong file, and wasn't using the libraries quite correctly. This PR corrects the path, and stops using the helper scripts so we can use the library commit from the submodule rather than re-downloading each time.