### PR TITLE
Fix bug with LED command.

### DIFF
--- a/src/firmware.cpp
+++ b/src/firmware.cpp
@@ -72,7 +72,7 @@ static CommandResponse analogueRead(int requestID, String argument) {
 }
 
 static CommandResponse led(int requestID, String argument) {
-
+  pinMode(LED_BUILTIN, OUTPUT);
   char state = argument.charAt(0);
 
   switch (state) {
@@ -329,4 +329,3 @@ void loop() {
     process_serial();
   }
 }
-


### PR DESCRIPTION
As all pins are set to INPUT on initialisation, this could cause the LED
command to be unable to control the LED as the direction register of Pin
13 is still set to INPUT before the W command is used on that pin.

I have deliberated not incremented the version number in this commit, as we can do that when #21 is merged.